### PR TITLE
Added journal club component of website

### DIFF
--- a/people.md
+++ b/people.md
@@ -32,6 +32,7 @@ permalink: /people/
 {: .person-name }
 ## David Hocker
 ![David Hocker](/images/Hocker.jpg){: .profile-photo }
+
 * Postdoctoral researcher, [Department of Neurobiology and Behavior (NBB)](https://medicine.stonybrookmedicine.edu/neurobiology), Stony Brook University (2016-current)
 
 ## Future lab member


### PR DESCRIPTION
This included restructuring the jekyll file structure by creating subfolders for each type of post in the website. The first is 
1). news. subfolder /news/ now contains its own _posts/ folder for all news updates, and index.md, which was originally named blog.md in the old version.
2). journalclub subfolder /journalclub/ now contains entries for all journal club entries, and index.md is the main page that displays those entries

Importantly, the posts now utilize the `category` type, which must exactly match the name of the subfolder. These are defined in the YML section of each individual post found in _posts. See the index.md files for how they are selected.
